### PR TITLE
Remove discontinued Coursera profile link

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,6 @@
             <a href="https://www.linkedin.com/in/l1fran3" target="_blank" rel="noopener">LinkedIn</a>
             <a href="https://github.com/olibartfast" target="_blank" rel="noopener">GitHub</a>
             <a href="https://www.youtube.com/user/olibartfast" target="_blank" rel="noopener">YouTube</a>
-            <a href="https://www.coursera.org/user/b7ef28a07fff79dfcb44e7119d7de3a7" target="_blank" rel="noopener">Coursera</a>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary

- remove the discontinued Coursera profile link from the homepage social links

## Why

Coursera has discontinued public learner profile pages. The existing URL now leads visitors to a “page no longer available” notice, while My Learning is private and cannot replace it as a public profile destination.

## Impact

Visitors will no longer encounter a dead Coursera link. LinkedIn, GitHub, and YouTube remain unchanged.

## Validation

- `npm test`
- `xmllint --html --noout index.html`
- `git diff --check`
